### PR TITLE
Simplify "call define" parser handling

### DIFF
--- a/lib/DojoAMDDefineDependencyParserPlugin.js
+++ b/lib/DojoAMDDefineDependencyParserPlugin.js
@@ -21,43 +21,56 @@ const DojoAMDRequireItemDependency = require("./DojoAMDRequireItemDependency");
 const DojoAMDRequireArrayDependency = require("./DojoAMDRequireArrayDependency");
 const ConstDependency = require("webpack/lib/dependencies/ConstDependency");
 const DojoAMDDefineDependency = require("./DojoAMDDefineDependency");
+const AMDDefineDependencyParserPlugin = require("webpack/lib/dependencies/AMDDefineDependencyParserPlugin");
 const LocalModuleDependency = require("webpack/lib/dependencies/LocalModuleDependency");
 const LocalModulesHelpers = require("webpack/lib/dependencies/LocalModulesHelpers");
 const AMDDefineDependency = require("webpack/lib/dependencies/AMDDefineDependency");
 
-module.exports = class DojoAMDDefineDependencyParserPlugin {
+module.exports = class DojoAMDDefineDependencyParserPlugin extends AMDDefineDependencyParserPlugin {
 	constructor(options, dojoRequire) {
+		super({});
 		this.options = options;
 		this.dojoRequire = dojoRequire;
 	}
 
-  apply(parser) {
-		parser.plugin("call define", (expr) => {
-			if (expr.dojoSkipFlag) return;
-			expr.dojoSkipFlag = true;
-			parser.state.current.isAMD = true;
-			const result = parser.applyPluginsBailResult("call define", expr);
-			delete expr.dojoSkipFlag;
+	// Overrides base class implementation.
+	newDefineDependency(range, arrayRange, functionRange, objectRange, namedModule) {
+		return new DojoAMDDefineDependency(range, arrayRange, functionRange, objectRange, namedModule);
+	}
 
-			if (result) {
-				// This is pretty hacky.  We want to avoid duplicating the implementation of the 'call define' plugin handler in
-				// AMDDefineDependencyParserPlugin, but it doesn't provide the ability to override the define dependency object
-				// creation so instead, we reach into the module's dependencies to find the instance of the AMDDefineDependency
-				// object and replace it our own.  There should only be one AMDDefineDependency of any given module.
-				const deps = parser.state.current.dependencies;
-				for (let i = deps.length-1; i >= 0; i--) {
-					const dep = deps[i];
-					if (dep instanceof AMDDefineDependency) {
-						const newDep = new DojoAMDDefineDependency(dep.range, dep.arrayRange, dep.functionRange, dep.objectRange, dep.namedModule);
-						newDep.loc = dep.loc;
-						newDep.localModule = dep.localModule;
-						deps[i] = newDep;
-						break;
-					}
+	apply(parser) {
+
+		super.apply(Object.assign(Object.create(parser), {
+			plugin: (expression, callback) => {
+				if (expression === "call define") {
+					// Augment base class implementation for "call define"
+					parser.plugin(expression, (expr) => {
+						parser.state.current.isAMD = true;
+						const result = callback(expr);	// invoke base class implementation
+						/* istanbul ignore if  */
+						if (!AMDDefineDependencyParserPlugin.prototype.newDefineDependency) {
+							// This is pretty hacky.  Earlier versions of webpack don't provide the newDefineDependency method allowing us
+							// to override the object creation, so instead, we reach into the module's dependencies to find the instance
+							// of the AMDDefineDependency object and replace it our own.  There should only be one AMDDefineDependency of
+							// any given module.
+							// The newDefineDependency method was introduced in webpack with https://github.com/webpack/webpack/pull/5783
+							const deps = parser.state.current.dependencies;
+							for (let i = deps.length-1; i >= 0; i--) {
+								const dep = deps[i];
+								if (dep instanceof AMDDefineDependency) {
+									const newDep = this.newDefineDependency(dep.range, dep.arrayRange, dep.functionRange, dep.objectRange, dep.namedModule);
+									newDep.loc = dep.loc;
+									newDep.localModule = dep.localModule;
+									deps[i] = newDep;
+									break;
+								}
+							}
+						}
+						return result;
+					});
 				}
 			}
-			return result;
-		});
+		}));
 
 		parser.plugin("call define:amd:array", (expr, param, identifiers, namedModule) => {
 			if(param.isArray()) {


### PR DESCRIPTION
Make "call define" parsing more explicit by invoking implementation in super-class rather than recursively invoking applyPlugins.  Overrides newly added `newDefineDependency` method in super-class (https://github.com/webpack/webpack/pull/5783) if available, or else falls back to old method of replacing the dependency object in the dependencies array if the method is not available.