### PR TITLE
GH-67 Unexpected webpack require behaviour

### DIFF
--- a/lib/DojoAMDMainTemplate.runtime.js
+++ b/lib/DojoAMDMainTemplate.runtime.js
@@ -86,7 +86,12 @@ module.exports = function() {
 			}
 		}
 		if (!result) {
-			throw new Error('Module not found: ' + mid);
+			var msg = 'Module not found: ' + mid;
+			if (noInstall) {
+				throw new Error(msg);
+			} else {
+				console.error(msg);
+			}
 		}
 		return result;
 	}

--- a/test/TestCases/dependencies/simple/index.js
+++ b/test/TestCases/dependencies/simple/index.js
@@ -39,6 +39,15 @@ define(["exports", "module", "./dep"], function(exports, module, dep) {
 		});
 	});
 
+	it("runtime require", function (done) {
+		var deps = ["missingModule", "test/dep"];
+		require(deps, function (reqMissingModule, reqDep) {
+			(typeof reqMissingModule).should.be.eql("undefined");
+			reqDep.should.be.eql(dep);
+			done();
+		});
+	});
+
 	dep.runTests();
 
 });


### PR DESCRIPTION
In WebPack calling require([x, y, z]), callback); where "y" does not exist, throws an exception.

In Dojo the same call would still callback with a valid x + z.

Fixes GH-67

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>