### PR TITLE
GH-67-2 runtime require behaviour

### DIFF
--- a/lib/DojoAMDMainTemplate.runtime.js
+++ b/lib/DojoAMDMainTemplate.runtime.js
@@ -86,12 +86,7 @@ module.exports = function() {
 			}
 		}
 		if (!result) {
-			var msg = 'Module not found: ' + mid;
-			if (noInstall) {
-				throw new Error(msg);
-			} else {
-				console.error(msg);
-			}
+			throw new Error('Module not found: ' + mid);
 		}
 		return result;
 	}
@@ -115,10 +110,18 @@ module.exports = function() {
 		}
 		if (type === '[object Array]') {
 			var modules = [], callback = a2;
-			a1.forEach(function(mid) {
-				modules.push(findModule(mid, referenceModule));
+			var foundAll = true;
+			a1.forEach(function (mid) {
+				try {
+					modules.push(findModule(mid, referenceModule));
+				} catch (e) {
+					console.error(e.message);
+					foundAll = false;
+				}
 			});
-			callback.apply(this, modules);
+			if (foundAll) {
+				callback.apply(this, modules);
+			}
 			return req;
 		} else {
 			throw new Error('Unsupported require call');


### PR DESCRIPTION
Rollback GH-67 changes
Calling require([x, y, z], callback) where any module is missing, should _not_
call the callback or throw an exception.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>