### PR TITLE
Fix issue with regex in loader config not exporting properly

### DIFF
--- a/lib/DojoAMDMainTemplatePlugin.js
+++ b/lib/DojoAMDMainTemplatePlugin.js
@@ -24,6 +24,7 @@
 const util = require('util');
 const ConcatSource = require("webpack-sources").ConcatSource;
 const Template = require("webpack/lib/Template");
+const stringify = require("node-stringify");
 
 module.exports = class DojoAMDMainTemplatePlugin {
 	constructor(options) {
@@ -127,7 +128,7 @@ module.exports = class DojoAMDMainTemplatePlugin {
 			if (util.isString(options.loaderConfig)) {
 				const dojoLoaderConfig = compilation.modules.find((module) => { return module.rawRequest === options.loaderConfig;});
 				s += this.requireFn + "(" + JSON.stringify(dojoLoaderConfig.id) + ");";
-				s += "if (typeof loaderConfig === 'function') loaderConfig = loaderConfig.call(globalScope, " + JSON.stringify(options.environment || {}) + ");";
+				s += "if (typeof loaderConfig === 'function') loaderConfig = loaderConfig.call(globalScope, " + stringify(options.environment || {}) + ");";
 			} else {
 				var loaderConfig;
 				if (typeof options.loaderConfig === 'function') {
@@ -135,11 +136,11 @@ module.exports = class DojoAMDMainTemplatePlugin {
 				} else {
 					loaderConfig = options.loaderConfig;
 				}
-				s += "Object.assign(globalScope.dojoConfig, " + JSON.stringify(loaderConfig) + ");";
+				s += "Object.assign(globalScope.dojoConfig, " + stringify(loaderConfig) + ");";
 			}
 			buf.push(s);
 			var defaultConfig = {hasCache:require("./defaultFeatures")};
-			buf.push("var defaultConfig = " + JSON.stringify(defaultConfig) + ";");
+			buf.push("var defaultConfig = " + stringify(defaultConfig) + ";");
 			buf.push("var dojoLoader = " + this.requireFn + "(" + JSON.stringify(dojoLoaderModule.id) + ");");
 			buf.push("dojoLoader.call(loaderScope, loaderConfig, defaultConfig, loaderScope, loaderScope);");
 			buf.push("req.has = loaderScope.require.has;");
@@ -156,9 +157,9 @@ module.exports = class DojoAMDMainTemplatePlugin {
 			if (util.isString(options.loaderConfig)) {
 				hash.update(options.loaderConfig);
 			} else if (typeof options.loaderConfig === 'function') {
-				hash.update(JSON.stringify(options.loaderConfig(options.environment || {})));
+				hash.update(stringify(options.loaderConfig(options.environment || {})));
 			} else {
-				hash.update(JSON.stringify(options.loaderConfig));
+				hash.update(stringify(options.loaderConfig));
 			}
 		});
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2794,6 +2794,11 @@
         }
       }
     },
+    "node-stringify": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-stringify/-/node-stringify-0.2.1.tgz",
+      "integrity": "sha512-EdzBiPO2hmQOpG8eZtJmBK0bAWPTdla2GAU4Tb7fztLkAiMEYcJAHWvC/4FI8E9ZOxB1zmoAJpM6upTQ54xNDw=="
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -3679,6 +3684,15 @@
         "xtend": "4.0.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3687,15 +3701,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "raw-loader": "0.5.1",
     "file-loader": "0.9.0",
+    "node-stringify": "0.2.1",
+    "raw-loader": "0.5.1",
     "tmp": "0.0.30"
   },
   "peerDependencies": {

--- a/test/TestCases/configLoading/buildEnv/index.js
+++ b/test/TestCases/configLoading/buildEnv/index.js
@@ -1,6 +1,7 @@
-define(["foo"], function(foo) {
+define(["foo", "fooalias"], function(foo, fooalias) {
 	it ("should load foo", function() {
 		foo.should.be.eql("foo");
+		fooalias.should.be.eql("foo");
 	});
 	it ("Should resolve foo as defined by environment", function() {
 		require.rawConfig.paths.foo.should.be.eql("/foo");

--- a/test/TestCases/configLoading/buildEnv/loaderConfig.js
+++ b/test/TestCases/configLoading/buildEnv/loaderConfig.js
@@ -4,6 +4,7 @@ module.exports = function(env) {
 		env.foopath.should.be.defined;
 	});
 	return {
-		paths: {foo: env.foopath}
+		paths: {foo: env.foopath},
+		aliases: [[/^fooalias$/, function() {return env.foopath;}]]
 	};
 };

--- a/test/TestCases/configLoading/buildEnvPlusEnv/index.js
+++ b/test/TestCases/configLoading/buildEnvPlusEnv/index.js
@@ -1,6 +1,7 @@
-define(["foo"], function(foo) {
+define(["foo", "fooalias"], function(foo, fooalias) {
 	it ("should load foo", function() {
 		foo.should.be.eql("foo");
+		fooalias.should.be.eql("foo");
 	});
 	it ("Should not resolve foo as defined by environment", function() {
 		(typeof require.rawConfig.paths.foo === 'undefined').should.be.true;

--- a/test/TestCases/configLoading/buildEnvPlusEnv/loaderConfig.js
+++ b/test/TestCases/configLoading/buildEnvPlusEnv/loaderConfig.js
@@ -1,6 +1,7 @@
 require("should");
 module.exports = function(env) {
 	return {
-		paths: {foo: env.foopath}
+		paths: {foo: env.foopath},
+		aliases: [[/^fooalias$/, function() {return env.foopath;}]]
 	};
 };

--- a/test/TestCases/configLoading/env/index.js
+++ b/test/TestCases/configLoading/env/index.js
@@ -1,6 +1,7 @@
-define(["foo"], function(foo) {
+define(["foo", "fooalias"], function(foo, fooalias) {
 	it ("should load foo", function() {
 		foo.should.be.eql("foo");
+		fooalias.should.be.eql("foo");
 	});
 
 	it ("Should resolve foo as defined by environment", function() {

--- a/test/TestCases/configLoading/env/loaderConfig.js
+++ b/test/TestCases/configLoading/env/loaderConfig.js
@@ -4,6 +4,7 @@ module.exports = function(env) {
 		env.foopath.should.be.eql("test/foo");
 	});
 	return {
-		paths: {foo: env.foopath}
+		paths: {foo: env.foopath},
+		aliases: [[/^fooalias$/, function() {return env.foopath;}]]
 	};
 };

--- a/test/TestCases/configLoading/noenv/index.js
+++ b/test/TestCases/configLoading/noenv/index.js
@@ -1,5 +1,6 @@
 define([], function() {
 	it ("Should resolve path as defined in loader config", function() {
 		require.toUrl('foo/bar').should.be.eql("/test/foo/bar");
+		require.toAbsMid('fooalias/bar').should.be.eql("/test/foo/bar");
 	});
 });

--- a/test/TestCases/configLoading/noenv/loaderConfig.js
+++ b/test/TestCases/configLoading/noenv/loaderConfig.js
@@ -4,6 +4,7 @@ module.exports = function(env) {
 		Object.keys(env).length.should.be.eql(0);
 	});
 	return {
-		paths: {foo: "/test/foo"}
+		paths: {foo: "/test/foo"},
+		aliases: [[/^fooalias(\/.*)?$/, function(__, $1) {return "/test/foo" + $1;}]]
 	};
 };

--- a/test/TestCases/configLoading/noenv/webpack.config.js
+++ b/test/TestCases/configLoading/noenv/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = [
 	entry: "./index",
 	plugins: [
 		new DojoWebpackPlugin({
-			loaderConfig: require.resolve("./loaderConfig"),
+			loaderConfig: require("./loaderConfig"),
 			loader: path.join(__dirname, "../../../js/dojo/dojo.js")
 		})
 	]


### PR DESCRIPTION
Fixes issue #82.  JSON.stringify doesn't serialize regex objects, so use node-stringify package instead.