### PR TITLE
Fix async timeout issues with unit test failures

### DIFF
--- a/test/TestCases/dependencies/cjsRequire/index.js
+++ b/test/TestCases/dependencies/cjsRequire/index.js
@@ -1,11 +1,15 @@
 /* global cjsRequire */
 define(["./amdModule"], function(amd) {
 	it("should load CommonJS modules using cjsRequire", function(done) {
-		amd.should.be.eql("amd");
-		cjsRequire("./cjsModule1").should.be.eql("cjs1");
-		require(["asyncDep"], function() {
-			done();
-		});
+		try {
+			amd.should.be.eql("amd");
+			cjsRequire("./cjsModule1").should.be.eql("cjs1");
+			require(["asyncDep"], function() {
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 	it("should load CommonJS module using cjsRequirePatterns option", function() {
 		require("./cjsModule3").should.be.eql("cjs3");

--- a/test/TestCases/dependencies/constContext/index.js
+++ b/test/TestCases/dependencies/constContext/index.js
@@ -1,14 +1,22 @@
 define("./subdir/a,./subdir/b".split(","), function(a, b) {
 	it("should load dependency relative to module b", function(done) {
-		b.loadc(function(c) {
-			c.should.be.eql("test/subdir/c");
-			done();
-		});
+		try {
+			b.loadc(function(c) {
+				c.should.be.eql("test/subdir/c");
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 	it("should load dependency relative to baseUrl", function(done) {
-		a.loadc(function(c) {
-			c.should.be.eql("test/c");
-			done();
-		});
+		try {
+			a.loadc(function(c) {
+				c.should.be.eql("test/c");
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 });

--- a/test/TestCases/dependencies/constDeps/asyncDep.js
+++ b/test/TestCases/dependencies/constDeps/asyncDep.js
@@ -15,10 +15,9 @@
  */
 define("module,exports".split(","), function(module, exports) {
 
-	it("test async require vars", function(done) {
+	it("test async require vars", function() {
 		module.id.should.eql("test/asyncDep");
 		module.exports.should.eql(exports);
-		done();
 	});
 
 	return "asyncDep";

--- a/test/TestCases/dependencies/constDeps/index.js
+++ b/test/TestCases/dependencies/constDeps/index.js
@@ -3,20 +3,18 @@ define("exports,module,./dep".split(","), function(exports, module, dep) {
 		done();
 	});
 
-	it("require scoping", function(done) {
+	it("require scoping", function() {
 		// verify require function hasn't been renamed;
 		var name = "req";
 		name += "uire";
 		eval(name).should.be.eql(require);
 		(typeof require.toUrl).should.be.eql("function");
 		(typeof require.toAbsMid).should.be.eql("function");
-		done();
 	});
 
-	it("defined vars" , function(done) {
+	it("defined vars" , function() {
 		exports.should.be.eql(exports);
 		module.id.should.be.eql("test/index");
-		done();
 	});
 
 	it("require", function(done) {
@@ -28,15 +26,19 @@ define("exports,module,./dep".split(","), function(exports, module, dep) {
 			exceptionThrown = true;
 		}
 		exceptionThrown.should.be.true();
-		require('require,module,exports,asyncDep,test/asyncDep'.split(','), function(require, reqModule, reqExports, asyncDep) {
-			reqModule.id.should.be.eql(module.id);
-			reqExports.should.be.eql(exports);
-			asyncDep.should.be.eql("asyncDep");
-			// context require
-			require("asyncDep").should.be.eql(asyncDep);
-			require('test/asyncDep').should.be.eql(asyncDep);
-			done();
-		});
+		try {
+			require('require,module,exports,asyncDep,test/asyncDep'.split(','), function(require, reqModule, reqExports, asyncDep) {
+				reqModule.id.should.be.eql(module.id);
+				reqExports.should.be.eql(exports);
+				asyncDep.should.be.eql("asyncDep");
+				// context require
+				require("asyncDep").should.be.eql(asyncDep);
+				require('test/asyncDep').should.be.eql(asyncDep);
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 
 	dep.runTests();

--- a/test/TestCases/dependencies/constNamedModules/index.js
+++ b/test/TestCases/dependencies/constNamedModules/index.js
@@ -29,11 +29,15 @@ if (versionParts[0] > 3 || versionParts[0] === 3 && versionParts[1] >= 7) {
 		});
 
 		it("should load the named modules in const require dependencies", function(done) {
-			require("named3,named4".split(','), function (named3, named4) {
-				"named3".should.be.eql(named3);
-				"named4".should.be.eql(named4);
-				done();
-			});
+			try {
+				require("named3,named4".split(','), function (named3, named4) {
+					"named3".should.be.eql(named3);
+					"named4".should.be.eql(named4);
+					done();
+				});
+			} catch(e) {
+				done(e);
+			}
 		});
 	});
 } else {

--- a/test/TestCases/dependencies/context/index.js
+++ b/test/TestCases/dependencies/context/index.js
@@ -1,14 +1,22 @@
 define(["./subdir/a", "./subdir/b"], function(a, b) {
 	it("should load dependency relative to module b", function(done) {
-		b.loadc(function(c) {
-			c.should.be.eql("test/subdir/c");
-			done();
-		});
+		try {
+			b.loadc(function(c) {
+				c.should.be.eql("test/subdir/c");
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 	it("should load dependency relative to baseUrl", function(done) {
-		a.loadc(function(c) {
-			c.should.be.eql("test/c");
-			done();
-		});
+		try {
+			a.loadc(function(c) {
+				c.should.be.eql("test/c");
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 });

--- a/test/TestCases/dependencies/namedModules/index.js
+++ b/test/TestCases/dependencies/namedModules/index.js
@@ -21,10 +21,14 @@ define(["named1", "named2"], function(named1, named2) {
 	});
 
 	it("should load the named modules in require dependencies", function(done) {
-		require(["named3", "named4"], function (named3, named4) {
-			"named3".should.be.eql(named3);
-			"named4".should.be.eql(named4);
-			done();
-		});
+		try {
+			require(["named3", "named4"], function (named3, named4) {
+				"named3".should.be.eql(named3);
+				"named4".should.be.eql(named4);
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 });

--- a/test/TestCases/dependencies/simple/asyncDep.js
+++ b/test/TestCases/dependencies/simple/asyncDep.js
@@ -1,9 +1,8 @@
 define(["module", "exports"], function(module, exports) {
 
-	it("test async require vars", function(done) {
+	it("test async require vars", function() {
 		module.id.should.eql("test/asyncDep");
 		module.exports.should.eql(exports);
-		done();
 	});
 
 	return "asyncDep";

--- a/test/TestCases/dependencies/simple/dep.js
+++ b/test/TestCases/dependencies/simple/dep.js
@@ -1,10 +1,9 @@
 define(["module", "exports"], function(module, exports) {
 	return {
 		runTests: function() {
-			it("module.id", function(done) {
+			it("module.id", function() {
 				module.exports.should.be.eql(exports);
 				module.id.should.be.eql("test/dep");
-				done();
 			});
 		}
 	};

--- a/test/TestCases/dependencies/simple/index.js
+++ b/test/TestCases/dependencies/simple/index.js
@@ -2,20 +2,18 @@ define(["exports", "module", "./dep"], function(exports, module, dep) {
 	it("should compile", function(done) {
 		done();
 	});
-	it("require scoping", function(done) {
+	it("require scoping", function() {
 		// verify require function hasn't been renamed
 		var name = "req";
 		name += "uire";
 		eval(name).should.be.eql(require);
 		(typeof require.toUrl).should.be.eql("function");
 		(typeof require.toAbsMid).should.be.eql("function");
-		done();
 	});
 
-	it("defined vars" , function(done) {
+	it("defined vars" , function() {
 		module.exports.should.be.eql(exports);
 		module.id.should.be.eql('test/index');
-		done();
 	});
 
 	it("require", function(done) {
@@ -28,16 +26,20 @@ define(["exports", "module", "./dep"], function(exports, module, dep) {
 		}
 		exceptionThrown.should.be.true();
 		/* global require */
-		require(['require', 'module', 'exports', 'asyncDep', 'test/asyncDep'], function(req, reqModule, reqExports, asyncDep) {
-			reqModule.id.should.be.eql(module.id);
-			reqExports.should.be.eql(exports);
-			asyncDep.should.be.eql("asyncDep");
-			// context require
-			require("asyncDep").should.be.eql(asyncDep);
-			require("test/asyncDep").should.be.eql(asyncDep);
-			req('./asyncDep').should.be.eql(asyncDep);
-			done();
-		});
+		try {
+			require(['require', 'module', 'exports', 'asyncDep', 'test/asyncDep'], function(req, reqModule, reqExports, asyncDep) {
+				reqModule.id.should.be.eql(module.id);
+				reqExports.should.be.eql(exports);
+				asyncDep.should.be.eql("asyncDep");
+				// context require
+				require("asyncDep").should.be.eql(asyncDep);
+				require("test/asyncDep").should.be.eql(asyncDep);
+				req('./asyncDep').should.be.eql(asyncDep);
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 
 	it("runtime require failures", function(done) {
@@ -67,35 +69,38 @@ define(["exports", "module", "./dep"], function(exports, module, dep) {
 			return done(new Error("rutime require callback should not be called"));
 		});
 
-		waitForError.then(function() {
-			// Call webpack's require.ensure to load the chunk containing test/asyncDep2
-			require.ensure(["test/asyncDep2"], function() {
-				// Synchonous require should still fail because module hasn't been defined.
-				try {
-					require('test/asyncDep2');
-					return done(new Error("Expected exception thrown"));
-				} catch(ignore) {}
+		try {
+			waitForError.then(function() {
+				// Call webpack's require.ensure to load the chunk containing test/asyncDep2
+				require.ensure(["test/asyncDep2"], function() {
+					// Synchonous require should still fail because module hasn't been defined.
+					try {
+						require('test/asyncDep2');
+						return done(new Error("Expected exception thrown"));
+					} catch(ignore) {}
 
-				waitForError = new Promise(function(resolve) {
-					var handle = require.on("error", function(error) {
-						handle.remove();
-						error.info.length.should.be.eql(1);
-						error.info[0].mid.should.be.eql("missing");
-						resolve();
+					waitForError = new Promise(function(resolve) {
+						var handle = require.on("error", function(error) {
+							handle.remove();
+							error.info.length.should.be.eql(1);
+							error.info[0].mid.should.be.eql("missing");
+							resolve();
+						});
+					});
+					// Async require should still fail because of "missing", but "test/asyncDep2"
+					// should have been loaded and initialized.
+					require(deps, function() {
+						return done(new Error("rutime require callback should not be called"));
+					});
+					waitForError.then(function() {
+						require("test/asyncDep2").should.be.eql("asyncDep2");
+						done();
 					});
 				});
-				// Async require should still fail because of "missing", but "test/asyncDep2"
-				// should have been loaded and initialized.
-				require(deps, function() {
-					return done(new Error("rutime require callback should not be called"));
-				});
-				waitForError.then(function() {
-					require("test/asyncDep2").should.be.eql("asyncDep2");
-					done();
-				});
-
 			});
-		});
+		} catch(e) {
+			done(e);
+		}
 	});
 	dep.runTests();
 });

--- a/test/TestCases/dependencies/varDeps/index.js
+++ b/test/TestCases/dependencies/varDeps/index.js
@@ -3,21 +3,25 @@ define(["require", "test/a"], function(require, a) {
 		done();
 	});
 	it("should load the module specified as a variable", function(done) {
-		a.should.be.eql("a");
-		var avar = "test/a";
-		var count = 2;
-		require([avar, "test/b"], function(_a, b) {
-			(a === _a).should.be.true();
-			b.b.should.be.eql("b");
-			b.a.should.be.eql("a");
-			if (--count === 0) done();
-		});
-		avar = "./a";
-		require([avar, "./b"], function(_a, b) {
-			(a === _a).should.be.true();
-			b.b.should.be.eql("b");
-			b.a.should.be.eql("a");
-			if (--count === 0) done();
-		});
+		try {
+			a.should.be.eql("a");
+			var avar = "test/a";
+			var count = 2;
+			require([avar, "test/b"], function(_a, b) {
+				(a === _a).should.be.true();
+				b.b.should.be.eql("b");
+				b.a.should.be.eql("a");
+				if (--count === 0) done();
+			});
+			avar = "./a";
+			require([avar, "./b"], function(_a, b) {
+				(a === _a).should.be.true();
+				b.b.should.be.eql("b");
+				b.a.should.be.eql("a");
+				if (--count === 0) done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 });

--- a/test/TestCases/has/constArrayFooUndefined/index.js
+++ b/test/TestCases/has/constArrayFooUndefined/index.js
@@ -5,11 +5,15 @@ define("require,dojo/has,dojo/has!foo?./a:./b".split(","), function(require, has
     m1.should.be.eql("b");
 		require("./b").should.be.eql(m1);
     has.add("foo", true, true, true);
-    require("dojo/has!foo?./c:./d,exports".split(","), function(m2) {
-      // module should have been set at build time and not changed just because foo changed
-      has("foo").should.be.ok();
-      m2.should.be.eql("c");
-      done();
-    });
+		try {
+	    require("dojo/has!foo?./c:./d,exports".split(","), function(m2) {
+	      // module should have been set at build time and not changed just because foo changed
+	      has("foo").should.be.ok();
+	      m2.should.be.eql("c");
+	      done();
+	    });
+		} catch(e) {
+			done(e);
+		}
   });
 });

--- a/test/TestCases/has/fooFalse/index.js
+++ b/test/TestCases/has/fooFalse/index.js
@@ -6,11 +6,15 @@ define(["require", "dojo/has", "dojo/has!foo?./a:./b", "dojo/has!foo?undef"], fu
     m1.should.be.eql("b");
 		(typeof undef === 'undefined').should.be.true();
     has.add("foo", true, true, true);
-    require(["dojo/has!foo?./c:./d"], function(m2) {
-      // module should have been set at build time and not changed just because foo changed
-      has("foo").should.be.ok();
-      m2.should.be.eql("d");
-      done();
-    });
+		try {
+	    require(["dojo/has!foo?./c:./d"], function(m2) {
+	      // module should have been set at build time and not changed just because foo changed
+	      has("foo").should.be.ok();
+	      m2.should.be.eql("d");
+	      done();
+	    });
+		} catch(e) {
+			done(e);
+		}
   });
 });

--- a/test/TestCases/has/fooTrue/index.js
+++ b/test/TestCases/has/fooTrue/index.js
@@ -4,11 +4,15 @@ define(["require", "dojo/has", "dojo/has!foo?./a:./b", "dojo/has!foo?:undef"], f
     m1.should.be.eql("a");
 		(typeof undef === 'undefined').should.be.true();
     has.add("foo", false, true, true);
-    require(["dojo/has!foo?./c:./d"], function(m2) {
-      has("foo").should.not.be.ok();
-			// module should have been set at build time and not changed just because foo changed
-      m2.should.be.eql("c");
-      done();
-    });
+		try {
+	    require(["dojo/has!foo?./c:./d"], function(m2) {
+	      has("foo").should.not.be.ok();
+				// module should have been set at build time and not changed just because foo changed
+	      m2.should.be.eql("c");
+	      done();
+	    });
+		} catch(e) {
+			done(e);
+		}
   });
 });

--- a/test/TestCases/has/fooUndefined/index.js
+++ b/test/TestCases/has/fooUndefined/index.js
@@ -5,11 +5,15 @@ define(["require", "dojo/has", "dojo/has!foo?./a:./b"], function(require, has, m
     m1.should.be.eql("b");
 		require("./b").should.be.eql(m1);
     has.add("foo", true, true, true);
-    require(["dojo/has!foo?./c:./d"], function(m2) {
-      // module should have been set at build time and not changed just because foo changed
-      has("foo").should.be.ok();
-      m2.should.be.eql("c");
-      done();
-    });
+		try {
+	    require(["dojo/has!foo?./c:./d"], function(m2) {
+	      // module should have been set at build time and not changed just because foo changed
+	      has("foo").should.be.ok();
+	      m2.should.be.eql("c");
+	      done();
+	    });
+		} catch(e) {
+			done(e);
+		}
   });
 });

--- a/test/TestCases/loaders/request/index.js
+++ b/test/TestCases/loaders/request/index.js
@@ -1,7 +1,11 @@
 define([], function() {
 	it("should compile", function(done) {
-		require(["dep"], function() {
-			done();
-		});
+		try {
+			require(["dep"], function() {
+				done();
+			});
+		} catch(e) {
+			done(e);
+		}
 	});
 });

--- a/test/TestCases/misc/undefApi/index1.js
+++ b/test/TestCases/misc/undefApi/index1.js
@@ -7,21 +7,25 @@ define(["require", "./a"], function(require, a) {
 			require("./a");
 			return done(new Error("Shouldn't get here"));
 		} catch (e) {}
-		require(["./a"], function(_a) {
-			a.should.be.eql(_a);
-			(a === _a).should.be.false;
-			require.undef("./a");
-			try {
-				require("./a");
-				return done(new Error("Shouldn't get here"));
-			} catch (e) {}
-			var dep = "./a";
-			require([dep], function(__a) {
-				a.should.be.eql(__a);
-				(a === __a).should.be.false;
-				(_a === __a).should.be.false;
-				done();
+		try {
+			require(["./a"], function(_a) {
+				a.should.be.eql(_a);
+				(a === _a).should.be.false;
+				require.undef("./a");
+				try {
+					require("./a");
+					return done(new Error("Shouldn't get here"));
+				} catch (e) {}
+				var dep = "./a";
+				require([dep], function(__a) {
+					a.should.be.eql(__a);
+					(a === __a).should.be.false;
+					(_a === __a).should.be.false;
+					done();
+				});
 			});
-		});
+		} catch(e) {
+			done(e);
+		}
 	});
 });


### PR DESCRIPTION
Unit tests that complete asynchronously incorrectly report timeouts when they fail because the exception thrown by the failed assert is not caught.  Add try/catch blocks to all async tests.