### PR TITLE
Improve client-side support for relative module ids with global require

### DIFF
--- a/lib/DojoAMDChunkTemplatePlugin.js
+++ b/lib/DojoAMDChunkTemplatePlugin.js
@@ -87,6 +87,6 @@ module.exports = class DojoAMDChunkTemplatePlugin {
 
 	hash(hash) {
 		hash.update("DojoAMDChunkTemplate");
-		hash.update("2");		// Increment this whenever the template code above changes
+		hash.update("3");		// Increment this whenever the template code above changes
 	}
 };

--- a/lib/DojoAMDMainTemplatePlugin.js
+++ b/lib/DojoAMDMainTemplatePlugin.js
@@ -23,6 +23,7 @@
 
 const path = require('path');
 const util = require('util');
+const commondir = require('commondir');
 const Template = require("webpack/lib/Template");
 const stringify = require("node-stringify");
 const {plugin} = require("./pluginHelper");
@@ -43,12 +44,12 @@ module.exports = class DojoAMDMainTemplatePlugin {
 				compilation:{value: compilation},
 				params:{value: params}
 			});
+			compilation.plugin("before-chunk-assets", this.relativizeAbsoluteAbsMids.bind(context));
 			plugin(compilation.mainTemplate, {
 				"bootstrap"               : this.bootstrap,
 				"require-extensions"      : this.requireExtensions,
 				"dojo-require-extensions" : this.dojoRequireExtensions, // plugin specific event
 				"render-dojo-config-vars" : this.renderDojoConfigVars, // plugin specific event
-				"set-emit-build-context"  : this.setEmitBuildContext, // plugin specific event
 				"hash"                    : this.hash
 			}, context);
 		});
@@ -131,13 +132,8 @@ but the loader specified at ${this.embeddedLoaderFilename} was built without the
 			}
 		}
 		buf.push(mainTemplate.applyPluginsWaterfall("render-dojo-config-vars", loaderScope, "", ...rest));
-		if (this.emitBuildContext) {
-			var context = path.resolve(this.compiler.context, this.options.globalContext || '.').replace(/\\/g,'/');
-			/* istanbul ignore else */
-			if (!context.endsWith('/')) {
-				context += '/';
-			}
-			buf.push(`loaderScope.buildContext = "${context}"`);
+		if (this.buildContext) {
+			buf.push(`loaderScope.buildContext = "${this.buildContext}"`);
 		}
 		buf.push("var dojoLoader = " + mainTemplate.requireFn + "(" + JSON.stringify(dojoLoaderModule.id) + ");");
 		buf.push("dojoLoader.call(loaderScope, userConfig, defaultConfig, loaderScope, loaderScope);");
@@ -205,14 +201,10 @@ but the loader specified at ${this.embeddedLoaderFilename} was built without the
 		return mainTemplate.asString(buf);
 	}
 
-	setEmitBuildContext() {
-		this.emitBuildContext = true;
-	}
-
 	hash(hash) {
 		const {options} = this;
 		hash.update("DojoAMDMainTemplate");
-		hash.update("9");		// Increment this whenever the template code above changes
+		hash.update("10");		// Increment this whenever the template code above changes
 		if (util.isString(options.loaderConfig)) {
 			hash.update(options.loaderConfig);	// loading the config as a module, so any any changes to the
 																					//   content will be detected at the module level
@@ -222,7 +214,83 @@ but the loader specified at ${this.embeddedLoaderFilename} was built without the
 			hash.update(stringify(options.loaderConfig));
 		}
 	}
+
 	getDefaultFeatures() {
 		return require("./defaultFeatures");
+	}
+
+	/**
+	 * Relativize absolute absMids.  Absolute absMids are created when global require is used with relative module ids.
+	 * They have the form '$$root$$/<absolute-path>' where '$$root$$' can be changed using the globalContext.varName
+	 * option.  So as not to expose absolute paths on the client for security reasons, we determine the closest common
+	 * directory for all the absolute absMids and rewrite the absMids in the form '$$root$$/<relative-path>', where the
+	 * path is relative to the buildContext path, and the buildContext path is calculated as the globalContext
+	 * directory relative to the closest common directory.  For example, if the globalContext path is '/a/b/c/d/e'
+	 * and the closest common directory is '/a/b/c', then the buildContext path would be'$$root$$/d/e', and the
+	 * modified absMid for the module with absolute absMid '$$root$$/a/b/c/d/f/foo' would be '$$root$$/d/f/foo'.  The
+	 * buildContext path is emitted to the client so that runtime global require calls specifying relative module ids
+	 * can be resolved on the client.  If at runtime, the client calls global require with the module id '../f/foo',
+	 * then the absMid for the module will be computed by resolving the specified module id against the buildContext
+	 * path ('$$root$$/d/e'), resulting in '$$root$$/d/f/foo' and the client will locate the module by looking
+	 * it up in the table of registered absMids.
+	 *
+	 * In the event that runtime global require calls attempt to traverse the buildContext parent hierarchy
+	 * beyond the level of the closest common directory, the globalContext.numParents option can be specified
+	 * to indicate the number of parent directories beyond the closest common directory to include in
+	 * the buildContext path.  In the example above, a numParents value of 1 would result in the buildContext
+	 * path changing from '$$root$$/d/e' to '$$root$$/c/d/e' and the absMid for the module with absolute path
+	 * '/a/b/c/d/f/foo' changing from '$$root$$/d/f/foo' to '$$root$$/c/d/f/foo'.
+	 */
+	relativizeAbsoluteAbsMids() {
+		const relAbsMids = [];
+		const relMods = [];
+		var rootVarName = this.options.getGlobalContextVarName();
+		// Gather the absMids that need to be rewritten, as well as the modules that contain them
+		this.compilation.modules.forEach(module => {
+			if (module.filterAbsMids) {
+				var foundSome = false;
+				module.filterAbsMids(absMid => {
+					if (absMid.startsWith(rootVarName + "/")) {
+						relAbsMids.push(path.dirname(absMid.substring(rootVarName.length + 1)));
+						foundSome = true;
+					}
+					return true;
+				});
+				if (foundSome) {
+					relMods.push(module);
+				}
+			}
+		});
+		if (relAbsMids.length) {
+			// Determine the closest common directory for all the root relative modules
+			var commonRoot = commondir(relAbsMids);
+			// Get the global context
+			var context = this.options.getGlobalContext(this.compiler);
+			// Adjust the closest common directory as specified by config
+			for (var i = 0; i < this.options.getGlobalContextNumParents(); i++) {
+				commonRoot = path.resolve(commonRoot, '..');
+			}
+			// Determine the relative path from the adjusted common root to the global context and set it
+			// as the build context that gets adorned and emitted to the client.
+			var relative = path.relative(commonRoot, context);
+			this.buildContext = path.join(rootVarName, relative).replace(/\\/g,'/');
+			if (!this.buildContext.endsWith('/')) {
+				this.buildContext += '/';
+			}
+			// Now rewrite the absMids to be relative to the computed build context
+			relMods.forEach(module => {
+				const toFix = [];
+				module.filterAbsMids(absMid => {
+					if (absMid.startsWith(rootVarName + "/")) {
+						toFix.push(absMid.substring(rootVarName.length + 1));
+						return false;
+					}
+					return true;
+				});
+				toFix.forEach(absMid => {
+					module.addAbsMid(path.normalize(path.join(rootVarName, relative, path.relative(context, absMid))).replace(/\\/g,'/'));
+				});
+			});
+		}
 	}
 };

--- a/lib/DojoAMDModuleFactoryPlugin.js
+++ b/lib/DojoAMDModuleFactoryPlugin.js
@@ -170,9 +170,8 @@ module.exports = class DojoAMDModuleFactoryPlugin {
 		if (dep && dep.usingGlobalRequire && data.request.startsWith('.')) {
 			// Global require with relative path.  Dojo resolves against the page.
 			// We'll resolve against the compiler context.
-			data.request = path.resolve(this.compiler.context, this.options.globalContext||'.', data.request);
-			this.addAbsMid(data, data.request.replace(/\\/g,'/'));
-			this.compilation.mainTemplate.applyPlugins("set-emit-build-context");
+			data.request = path.resolve(this.options.getGlobalContext(this.compiler), data.request);
+			this.addAbsMid(data, this.options.getGlobalContextVarName() + "/" + data.request);
 		}
 		this.factory.applyPluginsWaterfall("add absMids from request", data);
 		return callback(null, data);

--- a/lib/DojoAMDPlugin.js
+++ b/lib/DojoAMDPlugin.js
@@ -34,6 +34,9 @@ const ScopedRequirePlugin = require("./ScopedRequirePlugin");
 module.exports = class DojoAMDPlugin {
 	constructor(options) {
 		this.options = options;
+		this.options.getGlobalContext = this.getGlobalContext.bind(this);
+		this.options.getGlobalContextVarName = this.getGlobalContextVarName.bind(this);
+		this.options.getGlobalContextNumParents = this.getGlobalContextNumParents.bind(this);
 	}
 
 	apply(compiler) {
@@ -95,6 +98,32 @@ module.exports = class DojoAMDPlugin {
 		alias['dojo/i18n'] = path.resolve(__dirname, "..", "loaders", "dojo", "i18n");
 		alias['dojo/i18nRootModifier'] = path.resolve(__dirname, "..", "loaders", "dojo", "i18nRootModifier");
 		alias['dojo/loaderProxy'] = path.resolve(__dirname, "..", "loaders", "dojo", "loaderProxy");
+	}
+
+	getGlobalContextVarName() {
+		var result = '$$root$$';
+		if (this.options.globalContext && this.options.globalContext.varName) {
+			result = this.options.globalContext.varName;
+		}
+		return result;
+	}
+
+	getGlobalContext(compiler) {
+		var context = '.';
+		if (typeof this.options.globalContext === 'string') {
+			context = this.options.globalContext;
+		} else if (typeof this.options.globalContext === 'object') {
+			context = this.options.globalContext.context || '.';
+		}
+		return path.resolve(compiler.context, context);
+	}
+
+	getGlobalContextNumParents() {
+		var result = 0;
+		if (this.options.globalContext && this.options.globalContext.numParents) {
+			result = this.options.globalContext.numParents;
+		}
+		return result;
 	}
 
 	// Factories

--- a/package-lock.json
+++ b/package-lock.json
@@ -667,6 +667,11 @@
         "graceful-readlink": "1.0.1"
       }
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
+    "commondir": "1.0.1",
     "es6-class-mixin": "1.0.5",
     "file-loader": "0.9.0",
     "loader-utils": "1.1.0",

--- a/test/DojoAMDMainTemplatePlugin.test.js
+++ b/test/DojoAMDMainTemplatePlugin.test.js
@@ -24,13 +24,13 @@ describe("DojoAMDMainTemplatePlugin tests", function() {
 	beforeEach(function() {
 		mainTemplate = new MainTemplate();
 		const compiler = new Tapable();
+		const compilation = new Tapable();
 		plugin.apply(compiler);
-		compiler.applyPlugins("compilation", {	// compilation object
-			mainTemplate: mainTemplate,
-			modules: {
-				find: function() { return null; }
-			}
-		});
+		compilation.mainTemplate = mainTemplate;
+		compilation.modules = {
+			find: function() { return null; }
+		};
+		compiler.applyPlugins("compilation", compilation);
 	});
 
 	describe("dojo-require-extensions test", function() {

--- a/test/TestCases/dependencies/constGlobalRequire/index.js
+++ b/test/TestCases/dependencies/constGlobalRequire/index.js
@@ -5,7 +5,11 @@ define("require".split(','), function(req) {
 				asyncDep1.should.be.eql("global asyncDep");
 				asyncDep2.should.be.eql("local asyncDep");
 				require("./asyncDep").should.be.eql("global asyncDep");
-				require("../globalContext/asyncDep").should.be.eql("global asyncDep");
+				try {
+					// parent traversal should fail because we don't specify numParents
+					require("../globalContext/asyncDep");
+					return done(new Error("Shouldn't get here"));
+				} catch(e) {}
 				require("asyncDep").should.be.eql("local asyncDep");
 				done();
 			} catch (e) {

--- a/test/TestCases/dependencies/globalRequire/index.js
+++ b/test/TestCases/dependencies/globalRequire/index.js
@@ -1,12 +1,14 @@
 define(["require"], function(req) {
 	it("should load dep from global context", function(done) {
-		require(["./asyncDep", "asyncDep"], function(asyncDep1, asyncDep2) {
+		require(["./asyncDep", "asyncDep", "../asyncDep"], function(asyncDep1, asyncDep2, asyncDep3) {
 			try {
 				asyncDep1.should.be.eql("global asyncDep");
 				asyncDep2.should.be.eql("local asyncDep");
+				asyncDep3.should.be.eql("local asyncDep");
 				require("./asyncDep").should.be.eql("global asyncDep");
 				require("../globalContext/asyncDep").should.be.eql("global asyncDep");
 				require("asyncDep").should.be.eql("local asyncDep");
+				require("../asyncDep").should.be.eql("local asyncDep");
 				done();
 			} catch (e) {
 				done(e);
@@ -26,5 +28,14 @@ define(["require"], function(req) {
 				done(e);
 			}
 		});
+	});
+	it("should use " + require.rawConfig.testVarName + " for root relative module absMids", function() {
+		var error;
+		try {
+			require("./missing");
+		} catch(e) {
+			error = e;
+		}
+		error.message.should.containEql("not found: " + require.rawConfig.testVarName + "/");
 	});
 });

--- a/test/TestCases/dependencies/globalRequire/webpack.config.js
+++ b/test/TestCases/dependencies/globalRequire/webpack.config.js
@@ -9,7 +9,11 @@ module.exports = [contextdir, contextdir+'/'].map(context => {
 			new DojoWebpackPlugin({
 				loaderConfig: {
 					baseUrl: "../",
-					paths:{test: "."}
+					paths:{test: "."},
+					testVarName: "$$root$$"
+				},
+				globalContext: {
+					numParents: 1
 				},
 				loader: path.join(__dirname, "../../../js/dojo/dojo.js")
 			})
@@ -21,10 +25,14 @@ module.exports = [contextdir, contextdir+'/'].map(context => {
 		plugins: [
 			new DojoWebpackPlugin({
 				loaderConfig: {
-					paths:{test: "."}
+					paths:{test: "."},
+					testVarName: "$$root$$"
 				},
 				loader: path.join(__dirname, "../../../js/dojo/dojo.js"),
-				globalContext: context
+				globalContext: {
+					context: context,
+					numParents: 1
+				}
 			})
 		]
 	};
@@ -34,10 +42,15 @@ module.exports = [contextdir, contextdir+'/'].map(context => {
 		plugins: [
 			new DojoWebpackPlugin({
 				loaderConfig: {
-					paths:{test: "."}
+					paths:{test: "."},
+					testVarName: "%%root%%"
 				},
 				loader: path.join(__dirname, "../../../js/dojo/dojo.js"),
-				globalContext: context
+				globalContext: {
+					context: context,
+					numParents: 1,
+					varName: "%%root%%"
+				}
 			})
 		]
 	};


### PR DESCRIPTION
Improves client-side support for calling the global require function with relative module ids.  Client-side require is used when the function call or parameters cannot be resolved at build-time.

With this PR, the globalContext option can now be supplied as a string, or as an object.  If specified as a string, then it specifies the path against which relative module ids passed to the global require function on the client should be resolved.  If specified as an object, the following properties may be included:
<dl>
<dt>context</dt>
<dd>The same as when the property is specified as a string</dd>
<dt>varName</dt>
<dd>The string to use as the root component in internal representations of the module path on the client.  The default is <code>$$root$$</code>.  You generally don't need to be concerned with this unless it collides with package or path names in the Dojo loader config.</dd>
<dt>numParents</dt>
<dd>An integer specifying the number of extra parent directories to include in the context root used for resolving modules.  See the <code>relativizeAbsoluteAbsMids</code> method in <a href="https://github.com/OpenNTF/dojo-webpack-plugin/blob/master/lib/DojoAMDMainTemplatePlugin.js">DojoAMDMainTemplatePlugin.js</a> for the gory details of how this number is used.  If you get errors on the client when resolving module ids that traverse the parent hierarchy (e.g. <code>../../a/b/c</code>), then specifying a non-zero value for this property may help.</dd>
</dl>