### PR TITLE
Fix global object references to avoid issues with htm-webpack-plugin

### DIFF
--- a/lib/DojoAMDChunkTemplatePlugin.js
+++ b/lib/DojoAMDChunkTemplatePlugin.js
@@ -22,7 +22,7 @@
  */
 
 const {reg, tap, callSyncWaterfall} = require("./pluginCompat").for("dojo-webpack-plugin");
-const {getIndent, getAsString, modulesFromChunk, getGlobalObj} = require("./compat");
+const {getIndent, getAsString, modulesFromChunk} = require("./compat");
 
 module.exports = class DojoAMDChunkTemplatePlugin {
 	constructor(options) {
@@ -50,14 +50,14 @@ module.exports = class DojoAMDChunkTemplatePlugin {
 	render(source, chunk) {
 		const chunkTemplate = this.compilation.chunkTemplate;
 		const jsonpFn = JSON.stringify(chunkTemplate.outputOptions.jsonpFunction);
-		const globalObject = getGlobalObj(chunkTemplate, this.options);
 
 		const buf = [];
-		buf.push("");
-		buf.push(`${globalObject}[${jsonpFn}].registerAbsMids({`);
+		buf.push(";");
+		buf.push("(function(){");
+		buf.push(`(this||window)[${jsonpFn}].registerAbsMids({`);
 		buf.push(callSyncWaterfall(chunkTemplate, "render absMids", "", chunk));
-		buf.push("});");
-		buf.push("");
+		buf.push("})");
+		buf.push("})()");
 		source.add(this.asString(buf));
 		return source;
 	}

--- a/lib/DojoAMDMainTemplatePlugin.js
+++ b/lib/DojoAMDMainTemplatePlugin.js
@@ -24,7 +24,7 @@
 const util = require('util');
 const Template = require("webpack/lib/Template");
 const stringify = require("node-stringify");
-const {getAsString, getIndent, getGlobalObj, getRequireExtensionsHookName, needChunkLoadingCode, preWebpackV4} = require("./compat");
+const {getAsString, getIndent, getRequireExtensionsHookName, needChunkLoadingCode, preWebpackV4} = require("./compat");
 const {reg, tap, pluginName, callSyncBail, callSyncWaterfall} = require("./pluginCompat").for("dojo-webpack-plugin");
 
 module.exports = class DojoAMDMainTemplatePlugin {
@@ -88,20 +88,18 @@ module.exports = class DojoAMDMainTemplatePlugin {
 		                           .replace(/__webpack_require__/g, mainTemplate.requireFn);
 		const buf = [];
 		buf.push(runtimeSource);
+		buf.push("var globalObj = this||window;");
 		buf.push("registerAbsMids({");
 		buf.push(callSyncWaterfall(this.compilation.chunkTemplate, "render absMids", "", chunk));
 		buf.push("});");
 		buf.push("");
-		buf.push("(function(){ // Ensure this refers to global scope");
-		buf.push((callSyncWaterfall(mainTemplate, "dojo-global-require", "(this||window).require = req;")));
-		const globalObject = getGlobalObj(mainTemplate, this.options);
+		buf.push((callSyncWaterfall(mainTemplate, "dojo-global-require", "globalObj.require = req;")));
 		if(needChunkLoadingCode(chunk)) {
 			const jsonpFn = JSON.stringify(mainTemplate.outputOptions.jsonpFunction);
 			buf.push(this.indent(
-				`${globalObject}[${jsonpFn}].registerAbsMids = registerAbsMids;`
+				`(this||window)[${jsonpFn}].registerAbsMids = registerAbsMids;`
 			));
 		}
-		buf.push("})();");
 		buf.push("");
 		buf.push("// expose the Dojo compatibility functions as a properties of " + mainTemplate.requireFn);
 		const djProp = `${mainTemplate.requireFn}.${this.options.requireFnPropName}`;
@@ -111,17 +109,16 @@ module.exports = class DojoAMDMainTemplatePlugin {
 			"r: req,",
 			"c: createContextRequire,",
 			"m: dojoModuleFromWebpackModule,",
-			"h: resolveTernaryHasExpression,",
-			`g: ${globalObject}   // Easy access to global scope`
+			"h: resolveTernaryHasExpression"
 		]));
 		buf.push("};");
-		buf.push(`var loaderScope = {document:${globalObject}.document};`);
-		buf.push(`loaderScope.${globalObject} = loaderScope;`);
+		buf.push(`var loaderScope = {document:globalObj.document};`);
+		buf.push(`loaderScope.global = loaderScope.window = loaderScope;`);
 		const dojoLoaderModule = this.compilation.modules.find((module) => { return module.rawRequest === this.embeddedLoaderFilename;});
 		if (!dojoLoaderModule) {
 			throw Error("Can't locate " + this.embeddedLoaderFilename + " in compilation");
 		}
-		buf.push(`${globalObject}.dojoConfig = ${globalObject}.dojoConfig || {}`);
+		buf.push(`globalObj.dojoConfig = globalObj.dojoConfig || {}`);
 		var loaderScope;
 		if (!this.embeddedLoaderHasConfigApi) {
 			if (!util.isString(this.options.loaderConfig)) {
@@ -164,14 +161,13 @@ but the loader specified at ${this.embeddedLoaderFilename} was built without the
 		// the post-processed properties exported in the loaderScope should be used to specify the default config
 		var defaultConfig = {hasCache:this.getDefaultFeatures()};
 		const {mainTemplate} = this.compilation;
-		const globalObject = getGlobalObj(mainTemplate, this.options);
 		const buf = [];
 		// loader config props duplicated in default config when not using config api
 		if (util.isString(this.options.loaderConfig)) {
 			const dojoLoaderConfig = this.compilation.modules.find((module) => { return module.rawRequest === this.options.loaderConfig;});
 			buf.push(`var userConfig = ${mainTemplate.requireFn}(${JSON.stringify(dojoLoaderConfig.id)});`);
 			buf.push(`if (typeof userConfig === 'function') {`);
-			buf.push(this.indent(`userConfig = userConfig.call(${globalObject}, ${stringify(this.options.environment || {})});`));
+			buf.push(this.indent(`userConfig = userConfig.call(globalObj, ${stringify(this.options.environment || {})});`));
 			buf.push("}");
 		} else {
 			var loaderConfig = this.options.loaderConfig;
@@ -199,7 +195,7 @@ but the loader specified at ${this.embeddedLoaderFilename} was built without the
 				});
 				defaultConfig.hasCache = this.getDefaultFeatures();
 			}
-			buf.push(`var userConfig = mix(${globalObject}.dojoConfig, ${stringify(loaderConfig)});`);
+			buf.push(`var userConfig = mix(globalObj.dojoConfig, ${stringify(loaderConfig)});`);
 		}
 		buf.push(`var defaultConfig = ${stringify(defaultConfig)};`);
 		return this.asString(buf);

--- a/lib/compat.js
+++ b/lib/compat.js
@@ -73,9 +73,6 @@ module.exports = {
 			compiler.options.resolve.plugins.push(resolverFactory(options, compiler));
 		}
 	},
-	getGlobalObj(template, options) {
-		return template.outputOptions.globalObject || options.globalObject || "window";
-	},
 	getModuleTemplate(compilation) {
 		return  compilation.moduleTemplates ? compilation.moduleTemplates.javascript : compilation.moduleTemplate;
 	},


### PR DESCRIPTION
Can get "ReferenceError: window is not defined" errors from html-webpack-plugin when accessing the window object directly, so instead determine global object at run-time instead of build-time

This reverts commit f4eb866f803d7be8c4fc964e41a6ce7ff2095bb5.