### PR TITLE
Fix define-without-callback support

### DIFF
--- a/runtime/DojoAMDMainTemplate.runtime.js
+++ b/runtime/DojoAMDMainTemplate.runtime.js
@@ -132,8 +132,10 @@ module.exports = {
 						errors.push({mid: mid, error: e});
 					}
 				});
-				if (callback && errors.length === 0) {
-					callback.apply(this, modules);
+				if (errors.length === 0) {
+					if (callback) {
+						callback.apply(this, modules);
+					}
 				} else {
 					var error = new Error("findModules");
 					error.src = "dojo-webpack-plugin";


### PR DESCRIPTION
The fix for #158 didn't work unfortunately; it made it so that, when no callback is provided, the error handling block gets executed even when there are no errors. This patch corrects that control flow.

PR #159 added a unit test, but the test passes a callback to `define()` so it doesn't appear to validate what it was intended to. Since the tests rely on using the callback to resolve a promise, I'm not sure if it's practical to test the "no callback" case. If it'd be best to remove that unit test in this PR, lemme know.