### PR TITLE
Mix function bug & incorrect node version in child processes

### DIFF
--- a/lib/DojoLoaderPlugin.js
+++ b/lib/DojoLoaderPlugin.js
@@ -114,7 +114,7 @@ module.exports = class DojoLoaderPlugin {
 					}
 				}
 				child_process.execFile(
-					"node", // the executable to run
+					process.execPath, // the executable to run
 					[	// The arguments
 						path.resolve(__dirname, "../buildDojo", "buildRunner.js"),
 						"load=build",

--- a/runtime/DojoAMDMainTemplate.runtime.js
+++ b/runtime/DojoAMDMainTemplate.runtime.js
@@ -20,7 +20,7 @@ module.exports = {
 	main: function() {
 		function mix(dest, src) { // eslint-disable-line no-unused-vars
 			for(var n in src) dest[n] = src[n];
-			return src;
+			return dest;
 		}
 
 		function toUrl(name, referenceModule) {


### PR DESCRIPTION
While using the dojo webpack plugin, we encountered two issues, that we resolved in the commits below. Hereby, a pull request to fix these.