### PR TITLE
Fix issue with pre-mature promise resolution of second level dependencies

### DIFF
--- a/runtime/DojoAMDMainTemplate.runtime.js
+++ b/runtime/DojoAMDMainTemplate.runtime.js
@@ -219,8 +219,8 @@ module.exports = {
 			if (!isDefinePromise(defArray)) {
 				return defModule(defArray);
 			} else {
-				return setDefinePromise(Promise.all(wrapPromises(defArray)).then(function(deps) {
-					return unwrapPromises(defModule(unwrapPromises(deps)));
+				return setDefinePromise(Promise.all(defArray).then(function(deps) {
+					return wrapPromises(defModule(unwrapPromises(deps)));
 				}));
 			}
 		}

--- a/test/TestCases/loaders/asyncProxyLoader/dep.js
+++ b/test/TestCases/loaders/asyncProxyLoader/dep.js
@@ -1,0 +1,3 @@
+define(["test/thenableResult"], function(thenableResult) {
+	return thenableResult;
+});

--- a/test/TestCases/loaders/asyncProxyLoader/index.js
+++ b/test/TestCases/loaders/asyncProxyLoader/index.js
@@ -1,8 +1,10 @@
-define(["require", "test/asyncPlugin!foo/content.txt", "test/asyncPlugin!./content.txt", "test/asyncPlugin!"], function(req, content1, content2, content3) {
+define(["require", "test/asyncPlugin!foo/content.txt", "test/asyncPlugin!./content.txt", "test/asyncPlugin!", "test/thenableResult", "dep"], function(req, content1, content2, content3, thenableResult, dep) {
 	it("should load the resource name as the content", function(done) {
 		"Name = foo/content.txt".should.be.eql(content1);
 		"Name = ./content.txt".should.be.eql(content2);
 		"Name = ".should.be.eql(content3);
+		(typeof thenableResult.then).should.be.eql('function');
+		(typeof dep.then).should.be.eql('function');
 		done();
 	});
 	it("should load using context runtime require", function(done) {

--- a/test/TestCases/loaders/asyncProxyLoader/thenableResult.js
+++ b/test/TestCases/loaders/asyncProxyLoader/thenableResult.js
@@ -1,0 +1,5 @@
+define(["test/asyncPlugin!foobar"], function() {
+	return {then: function() {
+		throw new Error("then function should not be called");
+	}};
+});


### PR DESCRIPTION
When async option is true, if a module returns a promise value and the module is a second-level (or greater) dependency, then the module value would be the resolved value of the promise rather than the promise itself.