### PR TITLE
Fix issue with non-local main paths in package definitions

### DIFF
--- a/lib/DojoAMDMainTemplatePlugin.js
+++ b/lib/DojoAMDMainTemplatePlugin.js
@@ -26,6 +26,7 @@ const util = require('util');
 const Template = require("webpack/lib/Template");
 const stringify = require("node-stringify");
 const runtime = require("../runtime/DojoAMDMainTemplate.runtime");
+const loaderMainModulePatch = require("../runtime/DojoLoaderNonLocalMainPatch.runtime");
 const {getAsString, getIndent, getRequireExtensionsHookName, needChunkLoadingCode, preWebpackV4} = require("./compat");
 const {reg, tap, pluginName, callSyncBail, callSyncWaterfall} = require("webpack-plugin-compat").for("dojo-webpack-plugin");
 
@@ -152,6 +153,7 @@ but the loader specified at ${this.embeddedLoaderFilename} was built without the
 			// loaderProps.baseUrl is set by the loader config renderer if the loader has no config api.
 			buf.push("loaderScope.require.baseUrl = " + JSON.stringify(loaderScope.require.baseUrl) + ";");
 		}
+		buf.push(Template.getFunctionContent(loaderMainModulePatch));
 		buf.push("['baseUrl','has','rawConfig','on','signal'].forEach(function(name) {req[name] = loaderScope.require[name]})");
 		const loaderConfig = callSyncBail(this.compiler, "get dojo config");
 		if (loaderConfig.has && loaderConfig.has['dojo-undef-api']) {
@@ -217,7 +219,7 @@ but the loader specified at ${this.embeddedLoaderFilename} was built without the
 	hash(hash) {
 		const {options} = this;
 		hash.update("DojoAMDMainTemplate");
-		hash.update("10");		// Increment this whenever the template code above changes
+		hash.update("11");		// Increment this whenever the template code above changes
 		if (util.isString(options.loaderConfig)) {
 			hash.update(options.loaderConfig);	// loading the config as a module, so any any changes to the
 																					//   content will be detected at the module level

--- a/lib/DojoLoaderPlugin.js
+++ b/lib/DojoLoaderPlugin.js
@@ -18,6 +18,8 @@ const util = require('util');
 const path = require('path');
 const fs = require('fs');
 const vm = require("vm");
+const Template = require("webpack/lib/Template");
+const loaderMainModulePatch = require("../runtime/DojoLoaderNonLocalMainPatch.runtime");
 const {reg, tap, callSync, callSyncBail} = require("webpack-plugin-compat").for("dojo-webpack-plugin");
 const {containsModule} = require("./compat");
 const CommonJsRequireDependency = require("webpack/lib/dependencies/CommonJsRequireDependency");
@@ -153,7 +155,8 @@ module.exports = class DojoLoaderPlugin {
 		loaderScope.dojoConfig = Object.assign({}, loaderConfig);
 		loaderScope.dojoConfig.has = Object.assign({}, this.getDefaultFeaturesForEmbeddedLoader(), loaderScope.dojoConfig.has, {"dojo-config-api":1, "dojo-publish-privates":1});
 		var context = vm.createContext(loaderScope);
-		vm.runInContext('(function(global, window) {' + loader + '});', context, filename).call(context, context);
+		const patch = "(function(loaderScope){" + Template.getFunctionContent(loaderMainModulePatch) + "})(global);";
+		vm.runInContext('(function(global, window) {' + loader + patch + '});', context, filename).call(context, context);
 		return loaderScope;
 	}
 

--- a/runtime/DojoLoaderNonLocalMainPatch.runtime.js
+++ b/runtime/DojoLoaderNonLocalMainPatch.runtime.js
@@ -1,0 +1,67 @@
+/*
+ * (C) Copyright HCL Technologies Ltd. 2018, 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* globals module loaderScope */
+
+/*
+ * This module patches the Dojo loader to correct the behavior of toAbsMid
+ * with regards to package main modules.  The issue is that if the main module
+ * is specified as an absolute path or a relative path that resolves outside
+ * the package directory (e.g. ../../something), then toAbsMid returns an
+ * irrational path.  To work around this issue, we do the following:
+ *
+ * 1. Replace the main path used by Dojo with 'main', saving the real
+ *    main path in the 'realMain' property.  The causes Dojo's toAbsMid to return
+ *    an absMid like 'packageName/main'.
+ *
+ * 2. In our patched implementation of toUrl, we call the Dojo implementation
+ *    and fixup the url using the path saved in the 'realMain' property.
+ */
+module.exports = function() {
+	Object.keys(loaderScope.require.packs).forEach(function(key) {
+		var pkg = loaderScope.require.packs[key];
+		if ((/(^\/)|(\:)/.test(pkg.main)	// main path is absolute
+		    || pkg.main.split('/').reduce(function(acc, pathComp) {
+					if (acc < 0 || pathComp === '.') return acc;
+					return (pathComp === '..' ? --acc : ++acc);
+				}, 0) <= 0) // main path is outside package
+				&& typeof pkg.realMain === 'undefined'	// hasn't already been adjusted
+		) {
+			pkg.realMain = pkg.main;
+			pkg.main = 'main';
+		}
+	});
+	function toUrl(name, referenceModule) {
+		var absMid = loaderScope.require.toAbsMid(name, referenceModule);
+		var url = loaderScope.require.originalToUrl(absMid, referenceModule);
+		var match = /^([^/]*)\/main$/.exec(absMid);
+		var pkg = match && match[1] && loaderScope.require.packs[match[1]];
+		if (pkg && pkg.realMain) {
+			var parts = url.split('?');
+			if (/(^\/)|(\:)/.test(pkg.realMain)) {
+				// absolute URL
+				parts[0] = pkg.realMain;
+			} else {
+				// relative URL
+				parts[0] = parts[0].replace(/main$/, '') + pkg.realMain;
+			}
+			url = parts.join('?');
+		}
+		return url;
+	}
+	loaderScope.require.originalToAbsMid = loaderScope.require.toAbsMid;
+	loaderScope.require.originalToUrl = loaderScope.require.toUrl;
+	loaderScope.require.toUrl = toUrl;
+};

--- a/test/TestCases/misc/nonLocalMain/index.js
+++ b/test/TestCases/misc/nonLocalMain/index.js
@@ -1,0 +1,33 @@
+define(['dojo/has', 'foo', 'bar', 'foo/relPathTests', 'bar/relPathTests'], function(has, foo, bar, fooTests, barTests) {
+	it ("should load main modules from bar/main.js", function() {
+		foo.should.be.eql("bar/main");
+		bar.should.be.eql("bar/main");
+	});
+
+	it("should return correct value from toUrl", function()  {
+		require.toUrl("foo/main").should.be.eql('sub/foo/../../sub/bar/main');
+		require.toUrl("bar/main").should.be.eql('sub/bar/main');
+	});
+
+	it ("should run relPath tests successfully", function() {
+		fooTests();
+		barTests();
+	});
+
+	it ("should load main module from bar/main.js at runtime", function(done) {
+		var deps = [];
+		deps.push("foo");
+		deps.push("bar");
+		require(deps, function(rtFoo, rtBar) {
+			rtFoo.should.be.eql("bar/main");
+			rtBar.should.be.eql("bar/main");
+			done();
+		});
+	});
+
+	if (has('dojo-config-api')) {
+		it ("rawConfig should specify original main path", function() {
+			require.rawConfig.packages.find(function(pkg){return pkg.name==='foo';}).main.should.be.eql('../../sub/bar/main');
+		});
+	}
+});

--- a/test/TestCases/misc/nonLocalMain/loaderConfig.js
+++ b/test/TestCases/misc/nonLocalMain/loaderConfig.js
@@ -1,0 +1,10 @@
+module.exports = function(env) {
+	return {
+		paths:{test: "."},
+		packages:[
+			{name:"foo", location:"./sub/foo", main:"../../sub/bar/main"},
+			{name:"bar", location:"./sub/bar"}
+		],
+		has: {'host-browser':0, 'dojo-config-api':env.hasConfigApi}
+	};
+};

--- a/test/TestCases/misc/nonLocalMain/sub/bar/main.js
+++ b/test/TestCases/misc/nonLocalMain/sub/bar/main.js
@@ -1,0 +1,3 @@
+define([], function() {
+	return "bar/main";
+});

--- a/test/TestCases/misc/nonLocalMain/sub/bar/relPathTests.js
+++ b/test/TestCases/misc/nonLocalMain/sub/bar/relPathTests.js
@@ -1,0 +1,7 @@
+define(['require', '.'], function(require, main) {
+	return function() {
+		main.should.be.eql("bar/main");
+		require('.').should.be.eql("bar/main");
+		require.toUrl('bar/main').should.be.eql('sub/bar/main');
+	};
+});

--- a/test/TestCases/misc/nonLocalMain/sub/foo/main.js
+++ b/test/TestCases/misc/nonLocalMain/sub/foo/main.js
@@ -1,0 +1,3 @@
+define([], function() {
+	return "foo/main";
+});

--- a/test/TestCases/misc/nonLocalMain/sub/foo/relPathTests.js
+++ b/test/TestCases/misc/nonLocalMain/sub/foo/relPathTests.js
@@ -1,0 +1,7 @@
+define(['require', '.'], function(require, main) {
+	return function() {
+		main.should.be.eql("bar/main");
+		require('.').should.be.eql("bar/main");
+		require.toUrl('foo/main').should.be.eql('sub/foo/../../sub/bar/main');
+	};
+});

--- a/test/TestCases/misc/nonLocalMain/webpack.config.js
+++ b/test/TestCases/misc/nonLocalMain/webpack.config.js
@@ -1,0 +1,34 @@
+var path = require("path");
+var DojoWebpackPlugin = require("../../../../index");
+module.exports = [
+{
+	entry: "test/index",
+	plugins: [
+		new DojoWebpackPlugin({
+			loaderConfig: require.resolve("./loaderConfig"),
+			loader: path.join(__dirname, "../../../js/dojo/dojo.js"),
+			environment: {hasConfigApi: true}
+		})
+	]
+},
+{
+	entry: "test/index",
+	plugins: [
+		new DojoWebpackPlugin({
+			loaderConfig: require("./loaderConfig"),
+			loader: path.join(__dirname, "../../../js/noconfig/dojo/dojo.js"),
+			environment: {hasConfigApi: false}
+		})
+	]
+},
+{
+	entry: "test/index",
+	plugins: [
+		new DojoWebpackPlugin({
+			loaderConfig: require("./loaderConfig"),
+			loader: path.join(__dirname, "../../../js/dojo/dojo.js"),
+			environment: {hasConfigApi: true}
+		})
+	]
+}
+];


### PR DESCRIPTION
This PR patches the Dojo loader to correct the behavior of `toAbsMid`
 with regards to package main modules.  The issue is that if the main module
 is specified as an absolute path or a relative path that resolves outside
 the package directory (e.g. ../../something), then `toAbsMid` returns an
 irrational path.  To work around this issue, we do the following:
 
 1. Replace the main path used by Dojo with `main`, saving the real
 main path in the package definition's `realMain` property.  The causes Dojo's `toAbsMid` to return
 an absMid like `packageName/main`.
 
 2. In our patched implementation of `toUrl`, we call the Dojo implementation
 and fixup the url using the path saved in the `realMain` property.