### PR TITLE
Fix for non-local main modules

### DIFF
--- a/test/TestCases/misc/nonLocalMain/index.js
+++ b/test/TestCases/misc/nonLocalMain/index.js
@@ -5,8 +5,12 @@ define(['dojo/has', 'foo', 'bar', 'foo/relPathTests', 'bar/relPathTests'], funct
 	});
 
 	it("should return correct value from toUrl", function()  {
-		require.toUrl("foo/main").should.be.eql('sub/foo/../../sub/bar/main');
-		require.toUrl("bar/main").should.be.eql('sub/bar/main');
+		var fooAbsMid = require.toAbsMid("foo");
+		var barAbsMid = require.toAbsMid("bar");
+		fooAbsMid.should.be.eql("foo");
+		barAbsMid.should.be.eql("bar/main");
+		require.toUrl(fooAbsMid).should.be.eql('sub/foo/../../sub/bar/main');
+		require.toUrl(barAbsMid).should.be.eql('sub/bar/main');
 	});
 
 	it ("should run relPath tests successfully", function() {

--- a/test/TestCases/misc/nonLocalMain/sub/foo/relPathTests.js
+++ b/test/TestCases/misc/nonLocalMain/sub/foo/relPathTests.js
@@ -2,6 +2,6 @@ define(['require', '.'], function(require, main) {
 	return function() {
 		main.should.be.eql("bar/main");
 		require('.').should.be.eql("bar/main");
-		require.toUrl('foo/main').should.be.eql('sub/foo/../../sub/bar/main');
+		require.toUrl('foo').should.be.eql('sub/foo/../../sub/bar/main');
 	};
 });


### PR DESCRIPTION
The previous fix, #242, failed if you tried to load a module `packageName/main` that was not the package main module.  This PR fixes that problem.  The absMid returned for packages with non-local main modules is the package name itself.