### PR TITLE
Upgrade version of webpack-plugin-compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6385,9 +6385,9 @@
       }
     },
     "webpack-plugin-compat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-plugin-compat/-/webpack-plugin-compat-1.0.1.tgz",
-      "integrity": "sha512-mCFeieoXJDqFecib1ofvpHB+NqxRWHbZ5/NSlUa7Myb1j24zkCUS/0+r+i5VPyvUvCxQ/cLvMc5pj+6CHmv/gA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/webpack-plugin-compat/-/webpack-plugin-compat-1.0.3.tgz",
+      "integrity": "sha512-I7xumL18Msn83SVvJF9M/ytywiccPYD0Ll5Co9HjD4u7SEhrr+JHwD281+eedxKD6FxO+Uqpq+2uZKrqnfA9cQ=="
     },
     "webpack-sources": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node-stringify": "0.2.1",
     "raw-loader": "0.5.1",
     "tmp": "0.0.30",
-    "webpack-plugin-compat": "1.0.1"
+    "webpack-plugin-compat": "1.0.3"
   },
   "peerDependencies": {
     "webpack": ">= 2.2.0 < 4.0.0 || >= 4.2.0",


### PR DESCRIPTION
This pr should resolve #184 by allowing tapable to be upgraded when webpack is upgraded