### PR TITLE
Fix i18n module inclusion issue

### DIFF
--- a/loaders/dojo/i18nRootModifier/index.js
+++ b/loaders/dojo/i18nRootModifier/index.js
@@ -43,12 +43,16 @@ module.exports = function(content) {
 		return content;
 	}
 
+	function isLocaleMatch(a, b) {
+		return a === b || a.startsWith(b + '-') || b.startsWith(a + '-');
+	}
+
 	const requestedLocales = query.bundledLocales.split("|");
 	let modified = false;
 	Object.keys(bundle).forEach(bundleLocale => {
 		if (bundleLocale === "root" || !localeRegexp.test(bundleLocale)) return;
 		if (bundle[bundleLocale]) {
-			if (!requestedLocales.find(loc => loc === bundleLocale || bundleLocale.startsWith(loc + '-'))) {
+			if (!requestedLocales.find(loc => isLocaleMatch(loc, bundleLocale))) {
 				bundle[bundleLocale] = false;
 				modified = true;
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1675,10 +1675,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -1823,9 +1826,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
@@ -2805,9 +2808,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5938,13 +5941,13 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
+      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint . --ext .json --ext .md --ext .js",
     "pretest": "npm run clean:test && npm run lint && node buildDojo/build.js node_modules/dojo/dojo.js test/js && node buildDojo/build.js node_modules/dojo/dojo.js test/js/noconfig {\\\"dojo-config-api\\\":0}",
-    "test": "nyc mocha",
+    "test": "nyc node_modules/mocha/bin/mocha",
     "nopretest": "mocha",
     "travis:test": "npm run -s test",
     "cover": "clean:cover && nyc report --reporter=html",

--- a/test/TestCases/loaders/i18n/index.js
+++ b/test/TestCases/loaders/i18n/index.js
@@ -28,6 +28,8 @@ define([
 				case 'es':	hello = "Hola"; break;
 				case 'es-us':	hello = "Hola (US)"; break;
 				case 'en-au': hello = "G'day";
+				case 'it': hello = "Ciao"; goodby = "Bene da"; break;
+				case 'it-ch': hello = "Ciao (ch)"; goodby = "Bene da"; break;
 			}
 		}
 		strings1.hello.should.be.eql(hello);

--- a/test/TestCases/loaders/i18n/nls/it-ch/strings1.js
+++ b/test/TestCases/loaders/i18n/nls/it-ch/strings1.js
@@ -1,0 +1,3 @@
+define({
+	hello: 'Ciao (ch)'
+});

--- a/test/TestCases/loaders/i18n/nls/it/strings1.js
+++ b/test/TestCases/loaders/i18n/nls/it/strings1.js
@@ -1,0 +1,3 @@
+define({
+	hello: 'Ciao'
+});

--- a/test/TestCases/loaders/i18n/nls/it/strings2.js
+++ b/test/TestCases/loaders/i18n/nls/it/strings2.js
@@ -1,0 +1,3 @@
+define({
+	goodby: 'Bene da'
+});

--- a/test/TestCases/loaders/i18n/nls/strings1.js
+++ b/test/TestCases/loaders/i18n/nls/strings1.js
@@ -8,5 +8,7 @@ define({
 	"es":true,
 	"es-us":true,
 	"de":false,
+	"it":true,
+	"it-ch":true,
 	"not-a-locale": 0
 });

--- a/test/TestCases/loaders/i18n/nls/strings2.js
+++ b/test/TestCases/loaders/i18n/nls/strings2.js
@@ -5,6 +5,7 @@ define([], function() {
 	  }),
 		"fr":true,
 		"es":false,
-		"de":true
+		"de":true,
+		"it":true
 	};
 });

--- a/test/TestCases/loaders/i18n/webpack.config.js
+++ b/test/TestCases/loaders/i18n/webpack.config.js
@@ -2,7 +2,7 @@ var path = require("path");
 var DojoWebpackPlugin = require("../../../../index");
 
 module.exports = (
- [undefined, "en-us", "fr", "es", "de", "zh-hk"].map(locale => {
+ [undefined, "en-us", "fr", "es", "de", "it-ch", "zh-hk"].map(locale => {
 	return {
 		entry: "test/index",
 		plugins: [
@@ -12,14 +12,14 @@ module.exports = (
 					has: {"host-browser": 0, "dojo-config-api": 0},
 					locale: locale
 				},
-				locales: ["en", "fr", "es", "de", "zh-hk"],
+				locales: ["en", "fr", "es", "de", "it-ch", "zh-hk"],
 				loader: path.join(__dirname, "../../../js/dojo/dojo.js")
 			})
 		]
 	};
  })
 ).concat(
-	[undefined, "en-us", "fr", "es", "de", "zh-hk"].map(locale => {
+	[undefined, "en-us", "fr", "es", "de", "it", "it-ch", "zh-hk"].map(locale => {
 	return {
 		entry: "test/index",
 		plugins: [
@@ -35,7 +35,7 @@ module.exports = (
 	};
  })
 ).concat(
-	[undefined, "en-us", "fr", "es", "de", "zh-hk"].map(locale => {
+	[undefined, "en-us", "fr", "es", "de", "it", "it-ch", "zh-hk"].map(locale => {
 	return {
 		entry: "test/index",
 		plugins: [


### PR DESCRIPTION
If a country specific locale (e.g. es-us) is specified in the `locales` option but the non-country specific locale is omitted (e.g. es), then the resources for the non-country specific locale are not included in the compilation, causing the default locale to be used for resources that are not included in the country-specific resource bundle.