### PR TITLE
Improve support for test suite methods in unit tests

### DIFF
--- a/test/TestCases/misc/deprecatedReq/index.js
+++ b/test/TestCases/misc/deprecatedReq/index.js
@@ -6,24 +6,25 @@ define(["test/dep"], function(dep) {
 	it("should compile", function(done) {
 		done();
 	});
-	it("should output console warning for use of deprecated req", function() {
+	describe("Test use of deprecated ScopeRequirePlugin", function() {
 		var msg;
-		console.warn = function(message) {
-			msg = message;
-		};
-		dep.should.be.eql("dep");
-		require("test/dep").should.be.eql(dep);
-		msg.should.containEql("req is deprecated");
-	});
+		beforeEach(function() {
+			msg = null;
+			console.warn = function(message) {
+				msg = message;
+			};
+		});
+		it("should output console warning for use of deprecated req", function() {
+			dep.should.be.eql("dep");
+			require("test/dep").should.be.eql(dep);
+			msg.should.containEql("req is deprecated");
+		});
 
-	it("should output console warning for accessing deprecated property", function() {
-		// make sure accessing a property emits console warning
-		var msg;
-		console.warn = function(message) {
-			msg = message;
-		};
-		var rawConfig = require.rawConfig;
-		msg.should.containEql("req is deprecated");
-		rawConfig.paths.test.should.be.eql('.');
+		it("should output console warning for accessing deprecated property", function() {
+			// make sure accessing a property emits console warning
+			var rawConfig = require.rawConfig;
+			msg.should.containEql("req is deprecated");
+			rawConfig.paths.test.should.be.eql('.');
+		});
 	});
 });

--- a/test/TestCases/misc/es6Promise/index.js
+++ b/test/TestCases/misc/es6Promise/index.js
@@ -69,66 +69,60 @@ define(['amd/dojoES6Promise.js'], function(Promise) {
 		});
 		check = true;
 	});
+	describe("Test race/all", function() {
+		var promise1;
+		beforeEach(function() {
+			promise1 = new Promise(function(resolve) {
+				window.setTimeout(function() {
+					resolve("resolve1");
+				}, 10);
+			});
+		});
+		it("Promise.race should resolve correctly", function(done) {
+			var promise2 = new Promise(function() {});
+			Promise.race([promise1, promise2]).then(function(data) {
+				try {
+					data.should.be.eql("resolve1");
+					done();
+				} catch (err) {
+					done(err);
+				}
+			}).catch(function() {
+				done(new Error("Promise rejected"));
+			});
+		});
 
-	it("Promise.race should resolve correctly", function(done) {
-		var promise1 = new Promise(function(resolve) {
-			window.setTimeout(function() {
-				resolve("resolve1");
-			}, 10);
+		it("Promise.race should resolve correctly with non-promise entry", function(done) {
+			Promise.race([promise1, "resolve2"]).then(function(data) {
+				try {
+					data.should.be.eql("resolve2");
+					done();
+				} catch (err) {
+					done(err);
+				}
+			}).catch(function() {
+				done(new Error("Promise rejected"));
+			});
 		});
-		var promise2 = new Promise(function() {});
-		Promise.race([promise1, promise2]).then(function(data) {
-			try {
-				data.should.be.eql("resolve1");
-				done();
-			} catch (err) {
-				done(err);
-			}
-		}).catch(function() {
-			done(new Error("Promise rejected"));
-		});
-	});
 
-	it("Promise.race should resolve correctly with non-promise entry", function(done) {
-		var promise1 = new Promise(function(resolve) {
-			window.setTimeout(function() {
-				resolve("resolve1");
-			}, 10);
-		});
-		Promise.race([promise1, "resolve2"]).then(function(data) {
-			try {
-				data.should.be.eql("resolve2");
-				done();
-			} catch (err) {
-				done(err);
-			}
-		}).catch(function() {
-			done(new Error("Promise rejected"));
-		});
-	});
-
-	it("Promise.all should resolve correctly" , function(done) {
-		var promise1 = new Promise(function(resolve) {
-			window.setTimeout(function() {
-				resolve("resolve1");
-			}, 10);
-		});
-		var promise2 = new Promise(function(resolve) {
-			window.setTimeout(function() {
-				resolve("resolve2");
-			}, 100);
-		});
-		Promise.all([promise1, promise2, "resolve3"]).then(function(data) {
-			try {
-				data[0].should.be.eql("resolve1");
-				data[1].should.be.eql("resolve2");
-				data[2].should.be.eql("resolve3");
-				done();
-			} catch (err) {
-				done(err);
-			}
-		}).catch(function() {
-			done(new Error("Promise rejected"));
+		it("Promise.all should resolve correctly" , function(done) {
+			var promise2 = new Promise(function(resolve) {
+				window.setTimeout(function() {
+					resolve("resolve2");
+				}, 100);
+			});
+			Promise.all([promise1, promise2, "resolve3"]).then(function(data) {
+				try {
+					data[0].should.be.eql("resolve1");
+					data[1].should.be.eql("resolve2");
+					data[2].should.be.eql("resolve3");
+					done();
+				} catch (err) {
+					done(err);
+				}
+			}).catch(function() {
+				done(new Error("Promise rejected"));
+			});
 		});
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,7 @@ var path = require("path");
 var fs = require("fs");
 var vm = require("vm");
 var Test = require("mocha/lib/test");
+var Suite = require("mocha/lib/suite");
 var cloneDeep = require("clone-deep");
 var DojoWebackPlugin = require("../index");
 
@@ -130,11 +131,32 @@ function runTestCases(casesName) {
 								if(checkArrayExpectation(testDirectory, jsonStats, "warning", "Warning", done)) return;
 								var exportedTests = 0;
 
+								const suites = [suite];
 								function _it(title, fn) {
 									var test = new Test(title, fn);
-									suite.addTest(test);
+									suites[0].addTest(test);
 									exportedTests++;
 									return test;
+								}
+								function _describe(title, fn) {
+									const newSuite = new Suite(title, fn);
+									suites[0].addSuite(newSuite);
+									suites.unshift(newSuite);
+									fn();
+									suites.shift();
+									return newSuite;
+								}
+								function _beforeEach(fn) {
+									suites[0].beforeEach(fn);
+								}
+								function _beforeAll(fn) {
+									suites[0].beforeAll(fn);
+								}
+								function _afterEach(fn) {
+									suites[0].afterEach(fn);
+								}
+								function _afterAll(fn) {
+									suites[0].afterAll(fn);
 								}
 
 								var filesCount = 0;
@@ -156,10 +178,15 @@ function runTestCases(casesName) {
 											setInterval: setInterval,
 											clearTimeout: clearTimeout,
 											clearInterval: clearInterval,
-											Promise: Promise
+											Promise: Promise,
+											it: _it,
+											describe: _describe,
+											beforeEach: _beforeEach,
+											beforeAll: _beforeAll,
+											afterEach: _afterEach,
+											afterAll: _afterAll
 										});
 										context.global = context;
-										context.it = _it;
 										Object.defineProperty(context, "should", {
 									    set: function() {},
 									    get: function() {


### PR DESCRIPTION
Add support for `describe`, `beforeEach`, `afterEach`, `beforeAll` and `afterAll` in unit tests of compiled code.