### PR TITLE
Make sure dojo loader is not added more than once while building with webpack-dev-server

### DIFF
--- a/lib/DojoLoaderPlugin.js
+++ b/lib/DojoLoaderPlugin.js
@@ -212,7 +212,7 @@ module.exports = class DojoLoaderPlugin {
 
 	succeedModule(module) {
 		const {options} = this;
-		if (!module.issuer) {
+		if (!module.issuer && module.name !== 'main') {
 			// No issuer generally means an entry module, so add a Dojo loader dependency.  It doesn't
 			// hurt to add extra dependencies because the Dojo loader module will be removed from chunks
 			// that don't need it in the 'after-optimize-chunks' handler below.


### PR DESCRIPTION
The plugins exposes a dojo function as the main output of the bundle when building with webpack-dev-server. This change fixes it for me.