### PR TITLE
Allow remapping of locale specific language bundles by loader config

### DIFF
--- a/loaders/dojo/i18n/index.js
+++ b/loaders/dojo/i18n/index.js
@@ -99,7 +99,7 @@ module.exports = function(content) {
 					localeAbsMid = localeAbsMid.substring(0, localeAbsMid.length-3);
 				}
 				bundledLocales.push(loc);
-				deps.push(`${localeRes}?absMid=${localeAbsMid}`);
+				deps.push(localeAbsMid);
 			});
 		});
 

--- a/test/ErrorTestCases/options/missingLoader/expectedError.js
+++ b/test/ErrorTestCases/options/missingLoader/expectedError.js
@@ -1,5 +1,5 @@
 module.exports = {
 	test: function(error) {
-		return /Cannot find module \'.*[\/\\]dojo.js'$/.test(error);
+		return /Cannot find module \'.*[\/\\]dojo.js'/.test(error);
 	}
 };


### PR DESCRIPTION
Fix: Can't use loader config `paths`, `aliases`, etc. to remap locations of locale specific language bundles