### PR TITLE
added RuntimeModule.STAGE_BASIC to comply with webpack runtime dependencies

### DIFF
--- a/lib/DojoAMDRuntimeModule.js
+++ b/lib/DojoAMDRuntimeModule.js
@@ -7,7 +7,7 @@ const stringify = require("node-stringify");
 
 class DojoAMDRuntimeModule extends RuntimeModule {
 	constructor(chunk, set__, compiler) {
-		super(pluginName);
+		super(pluginName, RuntimeModule.STAGE_BASIC);
 		this.chunk = chunk;
 		this.pluginProps = getPluginProps(compiler);
 		this.options = this.pluginProps.options;


### PR DESCRIPTION
Hi!
I faced an issue with webpack runtime dependencies. I use ES modules in my project, that require additional webpack stuff in runtime. 
It builds fine, but final bundle throws an error on `dojoConfig` initialization because since I use different module type it rely on webpack runtime.
The actual error is:
```
Uncaught TypeError: __webpack_require__.nmd is not a function
```
Further investigation showed up that the problem is in runtime extensions order.
This change forces the `DojoAMDRuntimeModule` to insert it's runtime code after the webpack runtime code.

